### PR TITLE
fixing tasks sequence in watch task.

### DIFF
--- a/gulp/tasks/html.coffee
+++ b/gulp/tasks/html.coffee
@@ -9,4 +9,4 @@ gulp.task 'html', ->
   gulp.src("./#{root.src}/**/*.html")
   .pipe(template(package: pkg))
   .pipe(gulp.dest(root.dest))
-  .pipe(size(title: 'copy'))
+  .pipe(size(title: 'html'))

--- a/gulp/tasks/test.coffee
+++ b/gulp/tasks/test.coffee
@@ -1,5 +1,5 @@
 gulp = require 'gulp'
-runSequence = require 'run-sequence'
+sequence = require 'run-sequence'
 
 gulp.task 'test', (cb) ->
-  runSequence 'concat:tests', 'browserify:tests', 'watch', 'testem', cb
+  sequence 'concat:tests', 'browserify:tests', 'testem', 'watch:tests', cb

--- a/gulp/tasks/watch.coffee
+++ b/gulp/tasks/watch.coffee
@@ -1,10 +1,15 @@
 gulp = require 'gulp'
+sequence = require 'run-sequence'
+watch = require 'gulp-watch'
 
 {scripts, styles, tests} = require '../config/files'
 
 gulp.task 'watch', ->
-  gulp.watch scripts.watch, ['browserify:scripts', 'uglify']
-  gulp.watch styles.watch, ['styles', 'csso']
+  scriptsOptions = glob: scripts.watch, name: 'scripts', emitOnGlob: false
+  stylesOptions = glob: styles.watch, name: 'styles', emitOnGlob: false
+  watch scriptsOptions, -> sequence 'browserify:scripts', 'uglify'
+  watch stylesOptions, -> sequence 'styles', 'csso'
 
 gulp.task 'watch:tests', ->
-  gulp.watch tests.watch, ['concat:tests', 'browserify:tests']
+  testsOptions = glob: tests.watch, silent: true, emitOnGlob: false
+  watch testsOptions, -> sequence 'concat:tests', 'browserify:tests'

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-template": "^1.0.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^2.2.14",
+    "gulp-watch": "^0.6.9",
     "lodash": "^2.4.1",
     "mocha": "^1.20.1",
     "require-dir": "^0.1.0",

--- a/src/scripts/app.coffee
+++ b/src/scripts/app.coffee
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
Change gulp.watch for [gulp-watch](https://github.com/floatdrop/gulp-watch) plugin.
Tasks that run when watch detects a change now will run synchronously instead of asynchronously.
Watch task is silent in test workflow.
